### PR TITLE
[RFC] optimize zero_bss

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,8 @@ pub unsafe fn run_init_array(
     init_array_end: &extern "C" fn(),
 ) {
     let n = (init_array_end as *const _ as usize -
-             init_array_start as *const _ as usize) /
-            mem::size_of::<extern "C" fn()>();
+                 init_array_start as *const _ as usize) /
+        mem::size_of::<extern "C" fn()>();
 
     for f in slice::from_raw_parts(init_array_start, n) {
         f();
@@ -159,13 +159,14 @@ pub unsafe fn run_init_array(
 /// - `mem::size_of::<T>()` must be non-zero
 /// - `ebss >= sbss`
 /// - `sbss` and `ebss` must be `T` aligned.
-pub unsafe fn zero_bss<T>(sbss: *mut T, ebss: *mut T)
+pub unsafe fn zero_bss<T>(mut sbss: *mut T, ebss: *mut T)
 where
     T: Copy,
 {
-    let n = (ebss as usize - sbss as usize) / mem::size_of::<T>();
-
-    ptr::write_bytes(sbss, 0, n);
+    while sbss < ebss {
+        ptr::write_volatile(sbss, mem::zeroed());
+        sbss = sbss.offset(1);
+    }
 }
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,13 +122,18 @@ use core::{mem, ptr, slice};
 /// - The `sdata -> edata` region must not overlap with the `sidata -> ...`
 ///   region
 /// - `sdata`, `edata` and `sidata` must be `T` aligned.
-pub unsafe fn init_data<T>(sdata: *mut T, edata: *mut T, sidata: *const T)
-where
+pub unsafe fn init_data<T>(
+    mut sdata: *mut T,
+    edata: *mut T,
+    mut sidata: *const T,
+) where
     T: Copy,
 {
-    let n = (edata as usize - sdata as usize) / mem::size_of::<T>();
-
-    ptr::copy_nonoverlapping(sidata, sdata, n)
+    while sdata < edata {
+        ptr::write(sdata, ptr::read(sidata));
+        sdata = sdata.offset(1);
+        sidata = sidata.offset(1);
+    }
 }
 
 pub unsafe fn run_init_array(


### PR DESCRIPTION
with this change zero_bss *won't* be translated to memset / memclr (or
aeabi_mem{clr,set}4 on ARM), instead it will be translated into a loop that
zeroes the .bss section one word (or whatever T specifies) at a time (memclr
zeroes memory one byte at a time).

with this change and without having to change cortex-m-rt or msp430-rt this
reduces the size of an empty no-std program by 70 bytes (Cortex-M) and 20
bytes (MSP430) respectively. This should also speed up the MSP430 boot time as
well because zeroing would be performed in 16-bit chunks, rather than byte-wise.

The downside of this change is that if the application does make use of memset /
memclr then the size savings will be reversed: as zero_bss won't call memset /
memclr its routine will actually add to the binary size.

Should we do something similar for the init_data routine?

closes #3
cc @pftbest @therealprof @whitequark