### PR TITLE
Final 1.0 fixes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ keywords = ["initialization", "init", "start", "crt0", "c0"]
 categories = ["embedded", "no-std"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
-version = "0.2.2"
+version = "0.2.2" # don't forget to update html_root_url

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 
 #![deny(warnings)]
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/r0/0.2.2")]
 
 #[cfg(test)]
 mod test;
@@ -102,11 +103,8 @@ unsafe impl Word for u128 {}
 /// - The `sdata -> edata` region must not overlap with the `sidata -> ...`
 ///   region.
 /// - `sdata`, `edata` and `sidata` must be `T` aligned.
-pub unsafe fn init_data<T>(
-    mut sdata: *mut T,
-    edata: *mut T,
-    mut sidata: *const T,
-) where
+pub unsafe fn init_data<T>(mut sdata: *mut T, edata: *mut T, mut sidata: *const T)
+where
     T: Word,
 {
     while sdata < edata {


### PR DESCRIPTION
Closes out C-LINK and C-HTML-ROOT. I think [C-CRATE-DOC], [C-EXAMPLE], [C-QUESTION-MARK], [C-FAILURE], [C-LINK] are OK as it, with the extensive rustdoc at the crate level.

