### PR TITLE
Some final documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 # `r0`
 
-> Initialization code ("crt0") written in Rust
+Memory initialization code ("[crt0]") written in Rust.
 
-This project is developed and maintained by the [Cortex-A, Cortex-M, Cortex-R,
-MSP430, and RISCV teams][teams].
+This project is developed and maintained by the [Cortex-A, Cortex-M, Cortex-R, MSP430, and RISCV
+teams][teams].
+
+[crt0]: https://en.wikipedia.org/wiki/Crt0
 
 ## [Documentation](https://docs.rs/r0)
 


### PR DESCRIPTION
* Mention VMA/LMA
* Clarify that this only initializes memory
* Slightly improve formatting

This should address the remaining points in https://github.com/rust-embedded/r0/issues/12. I didn't add examples to *every* item because this crate is almost certainly only useful when using *all* of it.