### PR TITLE
Remove Travis CI badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # r0
 
-[![Build status](https://api.travis-ci.org/rust-embedded/r0.svg?branch=master)](https://travis-ci.org/rust-embedded/r0)
 [![crates.io](https://img.shields.io/crates/d/r0.svg)](https://crates.io/crates/r0)
 [![crates.io](https://img.shields.io/crates/v/r0.svg)](https://crates.io/crates/r0)
 


### PR DESCRIPTION
CI does not run on master, so this always says "build unknown". Tests always pass on master due to bors, so the badge provides no useful information to users.